### PR TITLE
[RFR] Date and room title

### DIFF
--- a/_posts/2014-05-26-press-release-for-the-first-general-assembly.md
+++ b/_posts/2014-05-26-press-release-for-the-first-general-assembly.md
@@ -30,7 +30,7 @@ The OCA mission is to support the collaborative development of the Odoo features
 
 # First OCA General Assembly
 
-During the OpenDays 2014, the first general assembly of Charter members will be held on June the 5th at 5:40pm in the Hocaille room. 
+During the OpenDays 2014, the first general assembly of Charter members will be held on June the 5th at 5:50pm in the Business for Partners room. 
 
 The first step to joining the general assembly is by filling the form at <a href="https://docs.google.com/forms/d/1uYhoEga_Lc-kUDobRpNP09L4lTHqya51ZlyZPlh31Eg/viewform">https://docs.google.com/forms/d/1uYhoEga_Lc-kUDobRpNP09L4lTHqya51ZlyZPlh31Eg/viewform</a>
 

--- a/translation/press_release_ga_es.md
+++ b/translation/press_release_ga_es.md
@@ -24,7 +24,7 @@ La misión de la OCA es soportar el desarrollo colaborativo de las característi
 
 # Primera Asamblea general.
 
-Durante los Opendays 2014 se llevará a cabo la primera asamblea de miembros la cuál será realizada en la fecha Junio 5 a las 5:40pm en la sala “Hocaille”.
+Durante los Opendays 2014 se llevará a cabo la primera asamblea de miembros la cuál será realizada en la fecha Junio 5 a las 5:50pm en la sala “Business for Partners”.
 
 El primer paso para unirte a la asamblea general es llenando el siguiente formulario.
 <a href="https://docs.google.com/forms/d/1uYhoEga_Lc-kUDobRpNP09L4lTHqya51ZlyZPlh31Eg/viewform">https://docs.google.com/forms/d/1uYhoEga_Lc-kUDobRpNP09L4lTHqya51ZlyZPlh31Eg/viewform</a>

--- a/translation/press_release_ga_fr.md
+++ b/translation/press_release_ga_fr.md
@@ -20,7 +20,7 @@ L’OCA a pour mission de soutenir le développement collaboratif des fonctionna
 
 # Première Assemblée Générale de l’OCA
 
-La première assemblée générale des membres aura lieu pendant les OpenDays 2014, le 5 juin à 17h40, dans la salle Hocaille.
+La première assemblée générale des membres aura lieu pendant les OpenDays 2014, le 5 juin à 17h50, dans la salle Business for Partners..
 
 La première étape pour participer à cette assemblée générale consiste à  remplir ce formulaire : <a href="https://docs.google.com/forms/d/1uYhoEga_Lc-kUDobRpNP09L4lTHqya51ZlyZPlh31Eg/viewform">https://docs.google.com/forms/d/1uYhoEga_Lc-kUDobRpNP09L4lTHqya51ZlyZPlh31Eg/viewform</a>
 

--- a/translation/press_release_ga_nl.md
+++ b/translation/press_release_ga_nl.md
@@ -22,7 +22,7 @@ De missie van de OCA is te ondersteunen dat op basis van samenwerking nieuwe fea
 
 # Eerste algemene vergadering van de OCA
 
-Gedurende de OpenDays 2014 zal de eerste algemene vergadering van kaderleden worden gehouden op 5 juni, om 17:40 in de Hocaille-zaal.
+Gedurende de OpenDays 2014 zal de eerste algemene vergadering van kaderleden worden gehouden op 5 juni, om 17:50 in de Business for Partners-zaal.
 
 De eerste stap om kaderlid te worden en de algemene vergadering bijwonen is om je aan te melden als regulier lid via het volgende formulier: <a href="https://docs.google.com/forms/d/1uYhoEga_Lc-kUDobRpNP09L4lTHqya51ZlyZPlh31Eg/viewform">https://docs.google.com/forms/d/1uYhoEga_Lc-kUDobRpNP09L4lTHqya51ZlyZPlh31Eg/viewform</a>
 

--- a/translation/press_release_ga_pt.md
+++ b/translation/press_release_ga_pt.md
@@ -20,7 +20,7 @@ A OCA tem como missão apoiar o desenvolvimento colaborativo das funcionalidades
 
 # Primeira Assembleia Geral da OCA
 
-A primeira assembleia geral dos membros acontecerá durante os OpenDays 2014, em 05 de Junho às 17h40, na sala Hocaille.
+A primeira assembleia geral dos membros acontecerá durante os OpenDays 2014, em 05 de Junho às 17h50, na sala Business for Partners.
 
 A primeira etapa para participar desta assembleia geral é preencher o formulário a seguir : <a href="https://docs.google.com/forms/d/1uYhoEga_Lc-kUDobRpNP09L4lTHqya51ZlyZPlh31Eg/viewform">https://docs.google.com/forms/d/1uYhoEga_Lc-kUDobRpNP09L4lTHqya51ZlyZPlh31Eg/viewform</a>
 

--- a/translation/press_release_ga_zh.md
+++ b/translation/press_release_ga_zh.md
@@ -22,7 +22,7 @@ Odoo联盟的使命是通过以下方式支持所有基于完善 Odoo 功能上�
 
 # 首届 OCA 成员大会
 
-在2014年度的 OpenDays 期间, 首届创会成员将会在 6月5日下午5点于 Hocaille 厅举行.
+在2014年度的 OpenDays 期间, 首届创会成员将会在 6月5日下午5点50分于 Business for Partners 厅举行.
 
 加入首届成员大会的第一步, 请先在这里填写表格 <a href="https://docs.google.com/forms/d/1uYhoEga_Lc-kUDobRpNP09L4lTHqya51ZlyZPlh31Eg/viewform">https://docs.google.com/forms/d/1uYhoEga_Lc-kUDobRpNP09L4lTHqya51ZlyZPlh31Eg/viewform</a>
 


### PR DESCRIPTION
The info on the link ( https://www.odoo.com/event/OpenDays-2014-5/track/OCA-General-Assembly-206) mentions 17:50, not 17:40. I guess we should update the times on the press releases (that would be 下午5点50分) and also update the location to 'Business for Partners' which seems to be the name used everywhere on the OpenDays site instead of Hocaille.
