### PR TITLE
[IMP] Clarify noupdate shouldn't be used for demo data

### DIFF
--- a/website/Contribution/CONTRIBUTING.rst
+++ b/website/Contribution/CONTRIBUTING.rst
@@ -348,8 +348,10 @@ When declaring a record in XML:
 * The tag `<data>` is only used to set not-updatable data with `noupdate=1`
   when your data file contains a mix of "noupdate" data. Otherwise, you should
   use one of these:
-  - `<odoo>`: for `noupdate=0`
+
+  - `<odoo>`: for `noupdate=0` or demo data (demo data is non-updatable by default)
   - `<odoo noupdate='1'>`
+
 * Do not prefix the xmlid by the current module's name
   (`<record id="view_id"...`, not `<record id="current_module.view_id"...`)
 


### PR DESCRIPTION
As demo data is non-updatable by default.

In addition, an RST syntax error is fixed that was causing a sub-list to
not be rendered correctly.