### PR TITLE
[FIX] CONTRIBUTING.rst: Update commit tag link

### DIFF
--- a/website/Contribution/CONTRIBUTING.rst
+++ b/website/Contribution/CONTRIBUTING.rst
@@ -1116,7 +1116,7 @@ changes. This part should be multiple lines no longer than 80 characters.
   being proposed
 * Use present imperative (Fix formatting, Remove unused field) avoid appending
   's' to verbs: Fixes, Removes
-* Use tags as `listed in the Odoo Guidelines <https://www.odoo.com/documentation/14.0/reference/guidelines.html#tag-and-module-name>`_ with the following extensions:
+* Use tags as `listed in the Odoo Guidelines <https://www.odoo.com/documentation/master/contributing/development/coding_guidelines.html#tag-and-module-name>`_ with the following extensions:
   - **[MIG]** for migrating a module
 
 .. code-block::


### PR DESCRIPTION
The previous link was being redirected to another page, which lost the anchor ref.