### PR TITLE
[IMP] Be more specific in sorting of model's private attributes

### DIFF
--- a/website/Contribution/CONTRIBUTING.rst
+++ b/website/Contribution/CONTRIBUTING.rst
@@ -905,7 +905,7 @@ Models
 
 * In a Model attribute order should be
 
-  #. Private attributes (`_name`, `_description`, `_inherit`, ...)
+  #. Private attributes (`_name`, `_inherit`, `_description`, ...)
   #. Fields declarations
   #. SQL constraints
   #. Default method and `_default_get`
@@ -919,9 +919,11 @@ Models
 .. code-block:: python
 
     class Event(models.Model):
-        # Private attributes
+        # Private attributes: model declaration (_name and inherits), _description, ...
         _name = 'event.event'
+        _inherit = ['event.event', 'mail.thread']
         _description = 'Event'
+        _order = 'name'
 
         # Fields declaration
         name = fields.Char(default=lambda self: self._default_name())


### PR DESCRIPTION
Private attributes for models are usually placed as follows:
- Model declaration:
  * Model name (`_name`)
  * Inheritances (`_inherit` and `_inherits`)
- Human readable name (`_description`)
- Other optional parameters (order, displayed name field, model-specific modifiers, etc)

However, current documentation could give the wrong impression the attribute `_inherit` goes after `_description`, which is not what is usually done.

This commit provides a recommended order for private attributes without explicitly requesting it.