### PR TITLE
Adding a CoC.rst proposal 

### DIFF
--- a/the-association/CoC.rst
+++ b/the-association/CoC.rst
@@ -1,0 +1,157 @@
+OCA Code of Conduct (Based on Contributor Covenant 3.0)
+=======================================================
+
+Overview
+--------
+
+The Odoo Community Association (OCA) adopts the
+`Contributor Covenant Code of Conduct, version 3.0 <https://www.contributor-covenant.org/version/3/0/code_of_conduct/>`_,
+as the foundation for our community standards.
+
+This document serves as an *OCA-specific supplement* to the Contributor Covenant,
+providing additional details and clarifications tailored to our community’s structure,
+communication channels, and governance model.
+
+By participating in OCA projects and activities, all members, contributors,
+and participants agree to follow both:
+
+* The core Contributor Covenant Code of Conduct (v3.0), and
+* The OCA-Specific Supplement defined below.
+
+This approach allows us to remain aligned with the globally recognized standard
+while including clear, concrete, and actionable community procedures.
+
+
+Repository Maintainers: How to Reference This Code
+--------------------------------------------------
+
+Each OCA-managed repository should include a short section in its
+``README.rst`` or a dedicated ``CODE_OF_CONDUCT.rst`` file referencing this document.
+
+Recommended template::
+
+    Code of Conduct
+    ---------------
+
+    This project follows the OCA Code of Conduct, based on the
+    Contributor Covenant 3.0.
+
+    See the full text here:
+    https://github.com/OCA/odoo-community.org/blob/main/the-association/OCA-Code-of-Conduct.rst
+
+This ensures a single authoritative document can be maintained and updated
+centrally by the OCA, while all repositories automatically reference the
+current version.
+
+
+OCA-Specific Supplement
+=======================
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+1. Scope Expansion
+------------------
+
+The Contributor Covenant’s definition of “community spaces” applies fully to the OCA.
+For clarity, the following specific spaces are included under this Code of Conduct:
+
+* OCA-managed GitHub repositories, issue trackers, and pull requests.
+* Official OCA mailing lists, discussion forums, and chat channels (e.g., Discord, Matrix, or other platforms).
+* OCA-hosted or sponsored events, including talks, sprints, conferences, and meetups.
+* Any public representation of OCA, including presentations or social media interactions,
+  when acting as a member or representative of the OCA community.
+
+This Code applies equally to community members, contributors, maintainers, event participants,
+sponsors, speakers, and any other stakeholders engaged in OCA activities.
+
+
+2. Reporting and Handling Procedure
+-----------------------------------
+
+To ensure consistency and transparency, the OCA maintains a dedicated
+**Community Health Working Group** responsible for receiving and addressing reports.
+
+**Reporting contact:**  
+All incidents or concerns related to Code of Conduct violations should be
+reported to:
+
+    **coc@odoo-community.org**
+
+Reports will be treated confidentially and handled with care, following these principles:
+
+* Reports are acknowledged within a reasonable timeframe.
+* The Community Health Working Group evaluates reports and, if appropriate, escalates to the OCA Board.
+* The identity of reporters is protected to the maximum extent possible.
+* Communication and outcomes are recorded, subject to privacy and data protection obligations.
+
+If a conflict of interest arises (e.g., a working group member is involved in the incident),
+they will recuse themselves from handling that case.
+
+Anonymous reports are accepted, though may limit the ability to investigate.
+
+
+3. Enforcement Guidelines
+-------------------------
+
+OCA follows the *restorative approach* defined in the Contributor Covenant v3.0 enforcement ladder.
+To provide additional clarity, the following examples illustrate how these stages may be applied
+within the OCA context.
+
+**3.1. Correction**
+
+Community moderators may request modification of language, tone, or behavior if it creates friction
+or misunderstanding. Examples include clarifying commit messages or rephrasing forum posts.
+
+**3.2. Warning**
+
+For minor or first-time incidents, a private warning may be issued describing the violation
+and expected corrective action.
+
+**3.3. Temporary Limitation**
+
+Participants may be temporarily suspended from one or more OCA communication channels,
+repositories, or events to cool down tensions or prevent further issues.
+
+**3.4. Suspension or Ban**
+
+Repeated or severe violations may result in longer suspensions or permanent removal from OCA spaces,
+including revocation of membership or conference participation.
+
+**3.5. Referral**
+
+In cases involving threats, harassment, or other unlawful behavior,
+the OCA may report the matter to appropriate local authorities.
+
+Whenever possible, enforcement actions aim to *repair harm and rebuild trust*,
+not merely to punish.
+
+Decisions are made by the Community Health Working Group in consultation with the OCA Board.
+
+
+4. Attribution and Versioning
+-----------------------------
+
+This supplement is designed to remain compatible with future releases of the
+Contributor Covenant Code of Conduct.
+
+* **Core text reference:** Contributor Covenant, version 3.0  
+  `<https://www.contributor-covenant.org/version/3/0/code_of_conduct/>`_
+
+* **Supplement text:** © Odoo Community Association, adapted from the
+  EuroPython 2020 Code of Conduct and released under the
+  `Creative Commons Attribution 4.0 International License (CC BY 4.0)
+  <https://creativecommons.org/licenses/by/4.0/>`_.
+
+When future versions of the Contributor Covenant are released,
+the OCA may update its reference version and keep this supplement unchanged,
+unless a review determines that adjustments are required to maintain alignment.
+
+---
+
+**Document Version:** 1.0 (OCA adaptation based on Contributor Covenant v3.0)  
+**Last updated:** |today|
+
+


### PR DESCRIPTION
A human-curated technology induced synthesis of a well established behavioural standard, the "Contributor Covenant 3.0 and the existing Code of Conduct (CoC) of the OCA. 

The idea that informed the instructions was agreed within the Governance WG meeting on the 7th of November 2025. It is to keep the well established standard (Contributor Covenant 3.0) and a modular and OCA specific supplement (OCA specifics) for easy updateability and maintenance. For full transparency refer to the full prompting, decision making and synthesis here https://chatgpt.com/c/690e05bc-0570-832b-b11a-eec7bf2b475c