### PR TITLE
[IMP] Add guideline for grouping and tagging inherited fields

### DIFF
--- a/website/Contribution/CONTRIBUTING.rst
+++ b/website/Contribution/CONTRIBUTING.rst
@@ -952,6 +952,10 @@ Models
         )
         price = fields.Integer(string='Price')
 
+        # Inherited fields
+        inherited_field = fields.Char(string="New string")
+        inherited_field_2 = fields.Char(readonly=True)
+
         # SQL constraints
         _sql_constraints = [
             ('name_uniq', 'unique(name)', 'Name must be unique'),
@@ -1014,6 +1018,11 @@ Fields
   .. code-block:: python
 
       a_field(..., default=lambda self: self._default_get())
+* New fields must be declared first, followed by any inherited or overridden fields.
+  If a model overrides or extends fields, a ``# Inherited fields`` comment must be
+  placed immediately before their declaration. This clearly distinguishes them from
+  new fields and accelerates version migrations by making upstream attribute or name
+  changes easier to audit.
 
 Exceptions
 ==========


### PR DESCRIPTION
Adding a new guideline in `CONTRIBUTING.rst` requiring new fields to be declared first, followed by an `# Inherited fields` comment block for any field overrides.

Explicitly ordering and tagging fields improves code readability, enables faster code reviews, and significantly streamlines the migration process when auditing upstream changes.